### PR TITLE
Refactor URLs and Channel views

### DIFF
--- a/bitvid/urls.py
+++ b/bitvid/urls.py
@@ -21,4 +21,4 @@ urlpatterns = patterns('',
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 urlpatterns += staticfiles_urlpatterns()
 
-handler404 = "main.views.notfound"
+handler404 = "main.views.NotFoundView"

--- a/bitvid/urls.py
+++ b/bitvid/urls.py
@@ -5,17 +5,8 @@ from django.conf.urls import patterns, include, url
 # admin.autodiscover()
 
 urlpatterns = patterns('',
-    url(r'^$', 'main.views.home', name='home'),
-    url(r'^login', 'main.views.login', name='login'),
-    url(r'^signup', 'main.views.signup', name='signup'),
-    url(r'^logout', 'main.views.logout', name='logout'),
-    url(r'^channels', 'main.views.channels', name='channels'),
-    url(r'^create_channel', 'main.views.create_channel', name='create_channel'),
-    url(r'^channel/(?P<channel>\w+)', 'main.views.view_channel', name='view_channel'),
-    url(r'^upload', 'main.views.upload', name='upload'),
-    url(r'^video/(?P<video_id>\d+)', 'main.views.view_video', name='view_video'),
-    url(r'^watch/(?P<video_id>\d+)', 'main.views.view_video', name='view_video'),
-    url(r'^(?P<video_id>\d+)', 'main.views.view_video', name='view_video'),
+    #'main' app urls module
+    url(r'', include('main.urls')),
     # Examples:
     # url(r'^$', 'bitvid.views.home', name='home'),
     # url(r'^bitvid/', include('bitvid.foo.urls')),

--- a/main/forms.py
+++ b/main/forms.py
@@ -1,6 +1,6 @@
 from django.forms import ModelForm
 from django import forms
-from main.models import User
+from main.models import User, Channel
 
 class SignupForm(ModelForm):
 
@@ -11,3 +11,19 @@ class SignupForm(ModelForm):
     class Meta:
         model = User
 	fields = ["username", "password", "email"]
+
+
+class LoginForm(ModelForm):
+
+    class Meta:
+        model = User
+        fields = ["username","password"]
+
+
+class ChannelForm(ModelForm):
+
+    class Meta:
+        model = Channel
+        fields = ["name"]
+
+

--- a/main/models.py
+++ b/main/models.py
@@ -8,6 +8,9 @@ from django.contrib.auth.models import AbstractBaseUser
 from django.core.exceptions import ValidationError
 import re
 from django.utils import timezone
+from django.core.urlresolvers import reverse
+
+
 
 class Channel(models.Model):
     name = models.CharField(max_length=64, unique=True)
@@ -22,6 +25,9 @@ class Channel(models.Model):
 
     status = models.CharField(max_length=2, choices=STATUS_CHOICES, default=STATUS_ACTIVE)
     subscribers = models.ManyToManyField('User', related_name="subscriptions")
+
+    def get_absolute_url(self):
+        return reverse("view_channel", kwargs={"slug": self.name}) 
 
     def clean(self):
         if len(self.name) < 2:

--- a/main/urls.py
+++ b/main/urls.py
@@ -1,0 +1,15 @@
+from django.conf.urls import patterns, url
+
+urlpatterns = patterns('',
+    url(r'^$', 'main.views.home', name='home'),
+    url(r'^login', 'main.views.login', name='login'),
+    url(r'^signup', 'main.views.signup', name='signup'),
+    url(r'^logout', 'main.views.logout', name='logout'),
+    url(r'^channels', 'main.views.channels', name='channels'),
+    url(r'^create_channel', 'main.views.create_channel', name='create_channel'),
+    url(r'^channel/(?P<channel>\w+)', 'main.views.view_channel', name='view_channel'),
+    url(r'^upload', 'main.views.upload', name='upload'),
+    url(r'^video/(?P<video_id>\d+)', 'main.views.view_video', name='view_video'),
+    url(r'^watch/(?P<video_id>\d+)', 'main.views.view_video', name='view_video'),
+    url(r'^(?P<video_id>\d+)', 'main.views.view_video', name='view_video'),
+)

--- a/main/urls.py
+++ b/main/urls.py
@@ -1,5 +1,6 @@
 from django.conf.urls import patterns, url
-from main.views import HomeView, ChannelDetailView, ChannelListView
+from main.views import HomeView, ChannelDetailView, ChannelListView,\
+    ChannelCreateView
 
 urlpatterns = patterns('',
     url(r'^$', HomeView.as_view(), name='home'),
@@ -7,7 +8,7 @@ urlpatterns = patterns('',
     url(r'^signup', 'main.views.signup', name='signup'),
     url(r'^logout', 'main.views.logout', name='logout'),
     url(r'^channels', ChannelListView.as_view(), name='channels'),
-    url(r'^create_channel', 'main.views.create_channel', name='create_channel'),
+    url(r'^create_channel', ChannelCreateView.as_view(), name='create_channel'),
     url(r'^channel/(?P<slug>\w+)', ChannelDetailView.as_view(), name='view_channel'),
     url(r'^upload', 'main.views.upload', name='upload'),
     url(r'^video/(?P<video_id>\d+)', 'main.views.view_video', name='view_video'),

--- a/main/urls.py
+++ b/main/urls.py
@@ -1,13 +1,14 @@
 from django.conf.urls import patterns, url
+from main.views import HomeView, ChannelDetailView, ChannelListView
 
 urlpatterns = patterns('',
-    url(r'^$', 'main.views.home', name='home'),
+    url(r'^$', HomeView.as_view(), name='home'),
     url(r'^login', 'main.views.login', name='login'),
     url(r'^signup', 'main.views.signup', name='signup'),
     url(r'^logout', 'main.views.logout', name='logout'),
-    url(r'^channels', 'main.views.channels', name='channels'),
+    url(r'^channels', ChannelListView.as_view(), name='channels'),
     url(r'^create_channel', 'main.views.create_channel', name='create_channel'),
-    url(r'^channel/(?P<channel>\w+)', 'main.views.view_channel', name='view_channel'),
+    url(r'^channel/(?P<slug>\w+)', ChannelDetailView.as_view(), name='view_channel'),
     url(r'^upload', 'main.views.upload', name='upload'),
     url(r'^video/(?P<video_id>\d+)', 'main.views.view_video', name='view_video'),
     url(r'^watch/(?P<video_id>\d+)', 'main.views.view_video', name='view_video'),


### PR DESCRIPTION
This pull request makes the following changes:
1. All of the Channel views, including creation, viewing a single Channel, and showing a user's Channels has been switched over to Django's generic Class Based Views.
2. The Home and 404 views are switched to Class Based Views
3. All of the main app URLs are moved to main.urls, and bitvid.urls is modified to include these URLs also
4. The Channel create view now uses a Django ModelForm class for validation
5. A stub ModelForm class for Login was created, for future incorporation and for demonstration of how ModelForm classes are declared
6. A LoginRequired mixin class is declared to mimic login_required but for class based views
7. Channel model class had get_absolute_url defined, a method which Django uses to look up the URL of where that instance is at. This is used for the redirection from the creation form and in the future would be used for editing.

This continues refactoring code into a more maintainable state, demonstrates the use of CBVs, and has a handful of minor improvements such as allowing the HTTP PUT method for creating new Channel objects.
