### PR TITLE
Fix for installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ Linux:
 /BitVid/BitVid > source bin/activate
 Windows: 
 /BitVid/BitVid > Scripts\activate.bat
-/BitVid/BitVid > pip install requirements.txt
+
+/BitVid/BitVid > pip install -r requirements.txt
 ```
 
 Setup the Database


### PR DESCRIPTION
Currently, the pip install command attempts to install requirements.txt, not load the contents of the requirements.txt file. This fixes that. 
